### PR TITLE
Fixes and Optimizations

### DIFF
--- a/debloat.sh
+++ b/debloat.sh
@@ -1,27 +1,23 @@
 #!/bin/sh
-package_file=packages.txt
+
 logfile=adb.log
-start=$(date +%s.%N)
-packages=$(cat $package_file)
-lines=$(wc -l < $package_file)
-removed=0
+start_time=`date +%s`
+total=$(grep -c ^ packages.txt)
+disabled=0
 
-printf "\n*** Removing defined packages, please wait ***\n\n"
-printf "\n*** Starting new run ***\n\n\n" >> $logfile
+adb shell echo Device Connected
 
-for app in $packages; do
-  #adb uninstall --user 0 "$app" > /dev/null 2>&1 && removed="$((removed+1))"   # Removes output instead of putting it in log (potential -q (quiet mode) flag)
-  adb uninstall --user 0 "$app" >> $logfile && removed="$((removed+1))" # sends everything to $logfile, not very useful without line numbers or filename.
-done
+rm $logfile 2>/dev/null
 
-printf "\n*** Finished ***\n" >> $logfile
+printf "\n*** Disabling defined packages, please wait ***\n\n"
 
-printf "Script Execution Time: $execution_time\n"
-if [ $removed = "0" ]; then
-  printf "No bloat to remove!\n\n"
+# Disable all packages in packages.txt and outputs to adb.log && get a line count of disabled apps
+xargs -l adb shell pm disable-user -k < packages.txt >> "$logfile" && disabled=$(grep -c ^ adb.log)
+
+echo Script Execution Time $(expr `date +%s` - $start_time)s
+
+if [ "$disabled" = '0' ]; then
+    echo No bloat to disable!
 else
-  printf "Removed %s out of %s packages\n" "$removed" "$lines"
+    echo "Disabled $disabled out of $total"
 fi
-
-duration=$(echo "$(date +%s.%N) - $start" | bc)
-execution_time=`printf "%.2f seconds" %s` $duration

--- a/debloat.sh
+++ b/debloat.sh
@@ -1,23 +1,24 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
-logfile=adb.log
-start_time=`date +%s`
+logfile="adb.log"
+start_time=$(date +%s)
 total=$(grep -c ^ packages.txt)
-disabled=0
+disabled="0"
 
 adb shell echo Device Connected
 
 rm $logfile 2>/dev/null
 
-printf "\n*** Disabling defined packages, please wait ***\n\n"
+printf "\n*** Disabling Defined Packages, Please Wait ***\n\n"
 
 # Disable all packages in packages.txt and outputs to adb.log && get a line count of disabled apps
-xargs -l adb shell pm disable-user -k < packages.txt >> "$logfile" && disabled=$(grep -c ^ adb.log)
+xargs -l adb shell pm disable-user -k < packages.txt >> "$logfile" && disabled=$(wc -l < $logfile)
 
-echo Script Execution Time $(expr `date +%s` - $start_time)s
+end_time=$(date +%s)
+printf "Script Execution Time %s\n" "$((end_time - start_time))s"
 
 if [ "$disabled" = '0' ]; then
-    echo No bloat to disable!
+    printf "No Bloat to Disable!\n\n"
 else
-    echo "Disabled $disabled out of $total"
+    printf "Disabled %s\n" "$disabled out of ""$total"
 fi


### PR DESCRIPTION
- Removed package_file variable because it was only used once
- Fixed time function
- Added ADB connection check
- Fixed line number count functions
- Switched to disable rather than uninstall (so you can re-enable if things go bad)
- Optimized disable function
- Switched to echo because printf wasn't needed for execution time or disabled output
- Switched variable names to read better